### PR TITLE
Add basic dispatcher simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# test-codex
+# Centrala Ruchu vZTM
+
+Prosta aplikacja symulująca stanowisko dyspozytora MZA Warszawa. Projekt powstał jako przykład użycia Leaflet.js oraz czystego JavaScriptu.
+
+## Uruchomienie
+
+Otwórz `index.html` w dowolnej przeglądarce z dostępem do internetu (wykorzystywane są zasoby CDN).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Centrala Ruchu vZTM</title>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+    <header>
+        <h1>Centrala Ruchu vZTM</h1>
+        <nav>
+            <select id="mode-select">
+                <option value="training">Tryb Szkoleniowy</option>
+                <option value="free">Tryb Swobodny</option>
+                <option value="exam">Tryb Egzamin</option>
+            </select>
+        </nav>
+    </header>
+    <main>
+        <div id="map"></div>
+        <aside id="panel">
+            <h2>Zgłoszenia</h2>
+            <ul id="reports"></ul>
+        </aside>
+    </main>
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/lines.json
+++ b/lines.json
@@ -1,0 +1,18 @@
+[
+  {
+    "nazwa": "521",
+    "kolor": "#007940",
+    "przebieg": [
+      [52.23, 21.00],
+      [52.22, 21.05],
+      [52.2044, 21.1643]
+    ],
+    "zdarzenia": [
+      {
+        "typ": "opóźnienie",
+        "opis": "Zator na ul. Patriotów",
+        "wspolrzedne": [52.2044, 21.1643]
+      }
+    ]
+  }
+]

--- a/script.js
+++ b/script.js
@@ -1,0 +1,48 @@
+const map = L.map('map').setView([52.2297, 21.0122], 12);
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+}).addTo(map);
+
+async function loadLines() {
+    const response = await fetch('lines.json');
+    const data = await response.json();
+    renderLines(data);
+    renderReports(data);
+}
+
+function renderLines(lines) {
+    lines.forEach(line => {
+        if (line.przebieg) {
+            L.polyline(line.przebieg, { color: line.kolor || '#000', weight: 5 })
+                .addTo(map);
+        }
+        if (line.zdarzenia) {
+            line.zdarzenia.forEach(event => {
+                const marker = L.marker(event.wspolrzedne)
+                    .addTo(map)
+                    .bindPopup(`<strong>${line.nazwa}</strong>: ${event.opis}`);
+                event._marker = marker; // store for later
+            });
+        }
+    });
+}
+
+function renderReports(lines) {
+    const reportsList = document.getElementById('reports');
+    lines.forEach(line => {
+        if (line.zdarzenia) {
+            line.zdarzenia.forEach(event => {
+                const li = document.createElement('li');
+                li.className = 'report-item';
+                li.textContent = `[${line.nazwa}] ${event.typ}: ${event.opis}`;
+                li.addEventListener('click', () => {
+                    map.setView(event.wspolrzedne, 15);
+                    if (event._marker) event._marker.openPopup();
+                });
+                reportsList.appendChild(li);
+            });
+        }
+    });
+}
+
+loadLines();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,43 @@
+body {
+    margin: 0;
+    font-family: Arial, sans-serif;
+}
+
+header {
+    background-color: #ffd800; /* yellow WTP */
+    padding: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-bottom: 4px solid #e30613; /* red WTP */
+}
+
+main {
+    display: flex;
+    height: calc(100vh - 60px);
+}
+
+#map {
+    flex: 1;
+}
+
+#panel {
+    width: 300px;
+    background: #fffbe6;
+    border-left: 1px solid #ccc;
+    overflow-y: auto;
+    padding: 10px;
+}
+
+#panel h2 {
+    margin-top: 0;
+}
+
+.report-item {
+    cursor: pointer;
+    padding: 5px;
+    border-bottom: 1px solid #ddd;
+}
+.report-item:hover {
+    background-color: #f0f0f0;
+}


### PR DESCRIPTION
## Summary
- build minimal Leaflet map interface for dispatcher simulator
- style UI with WTP colours
- implement JS logic to load lines and show reports
- provide sample `lines.json`
- update README with project info

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_684329846188832a96bdfd95e044e8f7